### PR TITLE
Python 3 Compatibility & Software update hook

### DIFF
--- a/octoprint_actiontrigger/__init__.py
+++ b/octoprint_actiontrigger/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import flask
 import logging
@@ -18,7 +18,7 @@ s = octoprint.plugin.plugin_settings("actiontrigger", defaults=default_settings)
 ##~~ Init Plugin and Metadata
 
 __plugin_name__ = "Action Trigger"
-
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_init__():
 		global _plugin

--- a/octoprint_actiontrigger/__init__.py
+++ b/octoprint_actiontrigger/__init__.py
@@ -27,7 +27,10 @@ def __plugin_init__():
 
 		_plugin = ActionTriggerPlugin()
 		__plugin_implementations__ = [_plugin]
-		__plugin_hooks__ = {'octoprint.comm.protocol.action': _plugin.hook_actiontrigger}
+		__plugin_hooks__ = {
+			'octoprint.comm.protocol.action': _plugin.hook_actiontrigger,
+			'octoprint.plugin.softwareupdate.check_config': _plugin.get_update_information
+		}
 
 class ActionTriggerPlugin(octoprint.plugin.TemplatePlugin,
 						  octoprint.plugin.AssetPlugin,
@@ -81,6 +84,26 @@ class ActionTriggerPlugin(octoprint.plugin.TemplatePlugin,
 						comm.setPause(True)
 						self._printer.home("x")
 						self.filament_action = True
+
+		def get_update_information(self):
+			# Define the configuration for your plugin to use with the Software Update
+			# Plugin here. See https://docs.octoprint.org/en/master/bundledplugins/softwareupdate.html
+			# for details.
+			return dict(
+				octoprint_actiontrigger=dict(
+					displayName="Action Trigger Plugin",
+					displayVersion=self._plugin_version,
+
+					# version check: github repository
+					type="github_release",
+					user="Booli",
+					repo="OctoPrint-ActionTriggerPlugin",
+					current=self._plugin_version,
+
+					# update method: pip
+					pip="https://github.com/Booli/OctoPrint-ActionTriggerPlugin/archive/{target_version}.zip"
+				)
+			)
 
 		# Send trigger to front end
 		def _send_client_message(self, message_type, data=None):


### PR DESCRIPTION
1. Added a software update hook, so that any users with this installed (At least 350 in the last month), can receive a pop-up notification from OctoPrint plugin manager to update the plugin. 

2. Added Python 3 compatibility (#2), only needed the flag adding. Tested all parts with the virtual printer.

Once you have merged these changes, go ahead and create a release and I'll update the repository to reflect Python 3 compatibility.